### PR TITLE
Another attempt at solving the form/main communication elegantly

### DIFF
--- a/src/Form.elm
+++ b/src/Form.elm
@@ -1,4 +1,4 @@
-module Form exposing (view, Model, init, update, Msg(CreateRecord))
+module Form exposing (view, Model, init, update, Msg, OutMsg(..))
 
 import Html exposing (..)
 import Html.Attributes exposing (id, for, attribute, class, type', value)
@@ -25,21 +25,24 @@ init =
 type Msg
     = UpdateFormTitle String
     | UpdateFormDescription String
-    | CreateRecord
+    | Submit
 
 
-update : Msg -> Model -> Model
+type OutMsg
+    = FormSubmitted
+
+
+update : Msg -> Model -> ( Model, Maybe OutMsg )
 update msg model =
     case msg of
         UpdateFormTitle title ->
-            { model | title = title }
+            ( { model | title = title }, Nothing )
 
         UpdateFormDescription description ->
-            { model | description = description }
+            ( { model | description = description }, Nothing )
 
-        CreateRecord ->
-            -- This is an "out message" for the parent
-            model
+        Submit ->
+            ( model, Just FormSubmitted )
 
 
 
@@ -48,7 +51,7 @@ update msg model =
 
 view : Model -> Html Msg
 view { title, description } =
-    form [ onSubmit CreateRecord ]
+    form [ onSubmit Submit ]
         [ div [ class "form-group" ]
             [ label [ for "title" ] [ text "Title" ]
             , input

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -29,7 +29,7 @@ type Msg
 
 
 type OutMsg
-    = FormSubmitted
+    = FormSubmitted Model
 
 
 update : Msg -> Model -> ( Model, Maybe OutMsg )
@@ -42,7 +42,8 @@ update msg model =
             ( { model | description = description }, Nothing )
 
         Submit ->
-            ( model, Just FormSubmitted )
+            ( init  -- empty the fields on submission
+            , Just (FormSubmitted model) )
 
 
 
@@ -58,7 +59,7 @@ view { title, description } =
                 [ id "title"
                 , type' "text"
                 , class "form-control"
-                  --, value title
+                , value title
                 , onInput UpdateFormTitle
                 ]
                 []
@@ -68,6 +69,7 @@ view { title, description } =
             , textarea
                 [ id "description"
                 , class "form-control"
+                , value description
                 , onInput UpdateFormDescription
                 ]
                 []

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -87,8 +87,9 @@ update msg model =
                     Nothing ->
                         ( { model | formData = updated }, Cmd.none )
 
-                    Just Form.FormSubmitted ->
-                        ( model, createRecord model.formData )
+                    Just (Form.FormSubmitted data) ->
+                        ( { model | formData = updated }
+                        , createRecord data )
 
         CreateSucceed _ ->
             ( { model | formData = Form.init }, fetchRecords )

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -4,7 +4,7 @@ import Task
 import HttpBuilder exposing (Response, Error, send, withJsonBody, withHeader, jsonReader, stringReader)
 import Json.Decode exposing (Decoder, string, at, list, object4, (:=), maybe, int)
 import Json.Encode as Encode
-import Form exposing (Msg(CreateRecord))
+import Form
 
 
 -- TODO:
@@ -78,11 +78,17 @@ update msg model =
         FetchRecordsFail err ->
             ( { model | error = True, errorMsg = (toString err) }, Cmd.none )
 
-        FormMsg CreateRecord ->
-            ( model, createRecord model.formData )
-
         FormMsg subMsg ->
-            ( { model | formData = Form.update subMsg model.formData }, Cmd.none )
+            let
+                ( updated, formMsg ) =
+                    Form.update subMsg model.formData
+            in
+                case formMsg of
+                    Nothing ->
+                        ( { model | formData = updated }, Cmd.none )
+
+                    Just Form.FormSubmitted ->
+                        ( model, createRecord model.formData )
 
         CreateSucceed _ ->
             ( { model | formData = Form.init }, fetchRecords )


### PR DESCRIPTION
This is imho a better, more explicit solution to the problem at hand
(communicating from the child to the parent that the form has been submitted).

Having a `Form.Msg.Submit` message is relevant I think, as I'll demonstrate in
another commit: if the Form module needs to do anything to the form when it's
submitted, regardless of what the parent does.
Eg: change the submit button to reflect the fact that it's been submitted,
maybe empty the input fields...
