### PR TITLE
Fix #4: Load bootstrap stylesheet in reactor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /elm-stuff
 /node_modules
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
 /elm-stuff
+/html/live/app.js
 /node_modules
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -2,9 +2,40 @@
 
 Experimenting with [Elm](elm-lang.org) and [Kinto](http://www.kinto-storage.org/).
 
+## Setup
+
+Node and Elm v0.17 should be installed on your system. Then:
+
+```
+$ npm install
+```
+
+## Development server
+
+```
+$ npm start
+```
+
+Then open [http://localhost:8000/html/dev.html](http://localhost:8000/html/dev.html).
+
+## Live server
+
+```
+$ npm live
+```
+
+Note: this won't load the stylesheets, we're working on it.
+
+## Deploying to gh-pages
+
+```
+$ npm run publish-to-gh-pages
+```
+
+Then result is visible [here](https://n1k0.github.io/kinto-elm-experiments).
+
 ## Tests
 
 ```
-$ npm i
 $ npm test
 ```

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ $ npm install
 $ npm start
 ```
 
-Then open [http://localhost:8000/html/dev.html](http://localhost:8000/html/dev.html).
+Then open [localhost:8000/html/dev.html](http://localhost:8000/html/dev.html).
 
 ## Live server
 
-```
-$ npm live
-```
+This will recompile and reload your app in the browser evertyme you update a `.elm` file. App is available at [localhost:8000/](http://localhost:8000/).
 
-Note: this won't load the stylesheets, we're working on it.
+```
+$ npm run live
+```
 
 ## Deploying to gh-pages
 

--- a/html/dev.html
+++ b/html/dev.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Kinto Elm Experiments (development)</title>
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+</head>
+
+<body>
+  <div style="width: 100%; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; color: #9A9A9A; font-family: &#39;Source Sans Pro&#39;;">
+    <div style="font-size: 3em;">Building your project!</div>
+    <img src="/_reactor/waiting.gif">
+    <div style="font-size: 1em">
+      With new projects, I need a bunch of extra time to download packages.
+    </div>
+  </div>
+</body>
+
+<script type="text/javascript" src="/_compile/src/Main.elm"></script>
+
+<!-- Removes splash and starts elm app. -->
+<script type="text/javascript">
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+  runElmProgram();
+</script>
+
+</html>

--- a/html/live/index.html
+++ b/html/live/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Kinto + Elm = &lt;3</title>
+    <title>Kinto Elm Experiments (live development)</title>
     <script src="/app.js"></script>
     <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" media="all" rel="stylesheet" />
   </head>

--- a/html/live/index.html
+++ b/html/live/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Kinto + Elm = &lt;3</title>
+    <script src="/app.js"></script>
+    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" media="all" rel="stylesheet" />
+  </head>
+
+  <body>
+    <div id="root"></div>
+  </body>
+
+  <script>
+    Elm.Main.embed(document.getElementById("root"));
+  </script>
+</html>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "node_modules/.bin/elm-make src/Main.elm --output=build/app.js",
     "start": "node_modules/.bin/elm-reactor",
-    "live": "node_modules/.bin/elm-live",
+    "live": "node_modules/.bin/elm-live src/Main.elm --output=html/live/app.js --dir=html/live",
     "publish-to-gh-pages": "npm run build && cp html/index.html build/ && node_modules/.bin/gh-pages --dist build/",
     "test": "node_modules/.bin/elm-test"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "node_modules/.bin/elm-make src/Main.elm --output=build/app.js",
+    "start": "node_modules/.bin/elm-reactor",
+    "live": "node_modules/.bin/elm-live",
     "publish-to-gh-pages": "npm run build && cp html/index.html build/ && node_modules/.bin/gh-pages --dist build/",
     "test": "node_modules/.bin/elm-test"
   },
@@ -20,6 +22,7 @@
   "homepage": "https://github.com/n1k0/kinto-elm-experiments#readme",
   "devDependencies": {
     "elm": "^0.17.1",
+    "elm-live": "^2.5.0",
     "elm-test": "^0.17.3",
     "gh-pages": "^0.11.0"
   }

--- a/src/View.elm
+++ b/src/View.elm
@@ -44,25 +44,7 @@ errorNotif error errorMsg =
     if error == True then
         div [ class "alert alert-danger" ] [ text ("Error: " ++ errorMsg) ]
     else
-        div [] [ text "" ]
-
-
-
---stylesheet : Html Msg
---stylesheet =
---    -- Silly hack to load bootstrap because other ways are clumsy.
---    let
---        tag =
---            "link"
---        attrs =
---            [ attribute "rel" "stylesheet"
---            , attribute "property" "stylesheet"
---            , attribute "href" "//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
---            ]
---        children =
---            []
---    in
---        node tag attrs children
+        text ""
 
 
 view : Model -> Html Msg
@@ -72,5 +54,4 @@ view { error, errorMsg, records, formData, currentTime } =
         , errorNotif error errorMsg
         , recordsList records currentTime
         , Html.App.map FormMsg (Form.view formData)
-          -- , stylesheet
         ]


### PR DESCRIPTION
Refs #4. This allows working with reactor and loading the bootstrap stylesheet through the use of a dedicated development HTML file.

Also added support for elm-live, though couldn't figure out how to specify a custom file path to the custom HTML file used (it must be at the root of the repo, which isn't nice). 

New docs:
## Setup

Node and Elm v0.17 should be installed on your system. Then:

```
$ npm install
```
## Development server

```
$ npm start
```

Then open [localhost:8000/html/dev.html](http://localhost:8000/html/dev.html).
## Live server

This will recompile and reload your app in the browser evertyme you update a `.elm` file. App is available at [localhost:8000/](http://localhost:8000/).

```
$ npm run live
```
## Deploying to gh-pages

```
$ npm run publish-to-gh-pages
```

Then result is visible [here](https://n1k0.github.io/kinto-elm-experiments).
## Tests

```
$ npm test
```
