### PR TITLE
Refetch records list on deleted record.

### DIFF
--- a/src/Model.elm
+++ b/src/Model.elm
@@ -117,7 +117,7 @@ update msg model =
                 | records = removeRecordFromList data model.records
                 , error = False
               }
-            , Cmd.none
+            , fetchRecords
             )
 
         DeleteRecordFail err ->


### PR DESCRIPTION
This will refetch the list of records when an entry is deleted. So we have optimistic, atomic and immediate local updates, and "synchronization" with the actual server state. Thoughts @magopian?
