### PR TITLE
Upgrade elm to 0.18, some refactoring

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,13 +8,13 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "NoRedInk/elm-decode-pipeline": "2.0.0 <= v < 3.0.0",
-        "elm-lang/core": "4.0.5 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0",
-        "lukewestby/elm-http-builder": "3.0.0 <= v < 4.0.0",
-        "mgold/elm-date-format": "1.1.4 <= v < 2.0.0",
-        "truqu/elm-base64": "1.0.4 <= v < 2.0.0"
+        "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "lukewestby/elm-http-builder": "4.0.0 <= v < 5.0.0",
+        "mgold/elm-date-format": "1.1.7 <= v < 2.0.0",
+        "truqu/elm-base64": "1.0.5 <= v < 2.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   },
   "homepage": "https://github.com/n1k0/kinto-elm-experiments#readme",
   "devDependencies": {
-    "elm": "^0.17.1",
-    "elm-live": "^2.5.0",
-    "elm-test": "^0.17.3",
+    "elm": "^0.18.0",
+    "elm-live": "^2.6.0",
+    "elm-test": "^0.18.0",
     "gh-pages": "^0.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "node_modules/.bin/elm-make src/Main.elm --output=build/app.js",
     "start": "node_modules/.bin/elm-reactor",
+    "debug": "node_modules/.bin/elm-live src/Main.elm --output=html/live/app.js --dir=html/live -- --debug",
     "live": "node_modules/.bin/elm-live src/Main.elm --output=html/live/app.js --dir=html/live",
     "publish-to-gh-pages": "npm run build && cp html/index.html build/ && node_modules/.bin/gh-pages --dist build/",
     "test": "node_modules/.bin/elm-test"

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -1,7 +1,7 @@
 module Form exposing (view, Model, init, update, Msg, OutMsg(..))
 
 import Html exposing (..)
-import Html.Attributes exposing (id, for, attribute, class, type', value)
+import Html.Attributes exposing (id, for, attribute, class, type_, value)
 import Html.Events exposing (onInput, onSubmit)
 import String
 
@@ -79,7 +79,7 @@ view model =
                 [ label [ for "title" ] [ text "Title" ]
                 , input
                     [ id "title"
-                    , type' "text"
+                    , type_ "text"
                     , class "form-control"
                     , value model.title
                     , onInput UpdateFormTitle
@@ -97,7 +97,7 @@ view model =
                     []
                 ]
             , div []
-                [ button [ type' "submit", class "btn btn-default" ]
+                [ button [ type_ "submit", class "btn btn-default" ]
                     [ text (formVerb model) ]
                 ]
             ]

--- a/src/Kinto.elm
+++ b/src/Kinto.elm
@@ -2,7 +2,7 @@ module Kinto exposing (..)
 
 import Base64
 import Http
-import Json.Decode as Json exposing ((:=))
+import Json.Decode as Json exposing (field)
 import String
 import Task exposing (Task)
 
@@ -11,12 +11,8 @@ type alias Url =
     String
 
 
-type alias Verb =
+type alias Method =
     String
-
-
-type alias Headers =
-    List ( String, String )
 
 
 
@@ -69,7 +65,7 @@ type Endpoint
 
 type alias Config =
     { baseUrl : String
-    , headers : Headers
+    , headers : List Http.Header
     , auth : Auth
     }
 
@@ -97,7 +93,7 @@ type alias StatusMsg =
 type Error
     = ServerError StatusCode StatusMsg String
     | KintoError StatusCode StatusMsg ErrorRecord
-    | NetworkError Http.RawError
+    | NetworkError Http.Error
 
 
 
@@ -141,25 +137,26 @@ endpointUrl config endpoint =
                 joinUrl [ baseUrl, "buckets", bucketName, "collections", collectionName, "records", recordId ]
 
 
-performQuery : Config -> Endpoint -> Verb -> Task Error Json.Value
-performQuery config endpoint verb =
+performQuery : Config -> Endpoint -> Method -> (Result Error Json.Value -> msg) -> Cmd msg
+performQuery config endpoint method toMsg =
     let
         request =
-            { verb = verb
-            , url = endpointUrl config endpoint
-            , headers = headersFromConfig config
-            , body = Http.empty
-            }
+            Http.request
+                { method = method
+                , headers = headersFromConfig config
+                , url = endpointUrl config endpoint
+                , body = Http.emptyBody
+                , expect = Http.expectJson bodyDataDecoder
+                , timeout = Nothing
+                , withCredentials = False
+                }
     in
-        ((Http.send Http.defaultSettings request)
-            |> Task.mapError NetworkError
-        )
-            `Task.andThen` (toKintoResponse >> Task.fromResult)
+        Http.send (toKintoResponse toMsg) request
 
 
 withHeader : String -> String -> Config -> Config
 withHeader name value ({ headers } as config) =
-    { config | headers = ( name, value ) :: headers }
+    { config | headers = (Http.header name value) :: headers }
 
 
 alwaysEncode : String -> String
@@ -172,7 +169,7 @@ alwaysEncode string =
             hash
 
 
-headersFromConfig : Config -> Headers
+headersFromConfig : Config -> List Http.Header
 headersFromConfig ({ auth, headers } as config) =
     case auth of
         NoAuth ->
@@ -180,7 +177,8 @@ headersFromConfig ({ auth, headers } as config) =
 
         Basic username password ->
             config
-                |> withHeader "Authorization"
+                |> withHeader
+                    "Authorization"
                     ("Basic " ++ (alwaysEncode (username ++ ":" ++ password)))
                 |> .headers
 
@@ -201,44 +199,50 @@ configure baseUrl auth =
 
 bodyDataDecoder : Json.Decoder Json.Value
 bodyDataDecoder =
-    ("data" := Json.value)
+    (field "data" Json.value)
 
 
 errorDecoder : Json.Decoder ErrorRecord
 errorDecoder =
-    Json.object4 ErrorRecord
-        ("errno" := Json.int)
-        ("message" := Json.string)
-        ("code" := Json.int)
-        ("error" := Json.string)
+    Json.map4 ErrorRecord
+        (field "errno" Json.int)
+        (field "message" Json.string)
+        (field "code" Json.int)
+        (field "error" Json.string)
 
 
-toKintoResponse : Http.Response -> Result Error Json.Value
-toKintoResponse ({ value, status, statusText } as response) =
-    (extractBody response)
-        `Result.andThen`
-            (extractData
-                >> Result.formatError (extractError status statusText)
-            )
+toKintoResponse :
+    (Result Error Json.Value -> msg)
+    -> Result Http.Error Json.Value
+    -> msg
+toKintoResponse toMsg response =
+    response
+        |> Result.mapError extractError
+        |> toMsg
 
 
-extractBody : Http.Response -> Result Error String
-extractBody { value, status, statusText } =
-    case value of
-        Http.Text body ->
-            Ok body
+extractError : Http.Error -> Error
+extractError error =
+    case error of
+        Http.BadStatus { status, body } ->
+            extractKintoError status.code status.message body
 
-        _ ->
-            Err (ServerError status statusText "Unsupported response body")
+        Http.BadPayload str { status, body } ->
+            ServerError
+                status.code
+                status.message
+                ("failed decoding json: "
+                    ++ str
+                    ++ "\n\nBody received from server: "
+                    ++ body
+                )
+
+        anyError ->
+            NetworkError anyError
 
 
-extractData : String -> Result String Json.Value
-extractData data =
-    Json.decodeString bodyDataDecoder data
-
-
-extractError : StatusCode -> StatusMsg -> String -> Error
-extractError statusCode statusMsg body =
+extractKintoError : StatusCode -> StatusMsg -> String -> Error
+extractKintoError statusCode statusMsg body =
     case Json.decodeString errorDecoder body of
         Ok errRecord ->
             KintoError statusCode statusMsg errRecord
@@ -252,29 +256,43 @@ extractError statusCode statusMsg body =
 -- GET
 
 
-getBucketList : Config -> Task Error Json.Value
+getBucketList : Config -> (Result Error Json.Value -> msg) -> Cmd msg
 getBucketList config =
     performQuery config BucketListEndpoint "GET"
 
 
-getBucket : Config -> BucketName -> Task Error Json.Value
+getBucket : Config -> BucketName -> (Result Error Json.Value -> msg) -> Cmd msg
 getBucket config bucket =
     performQuery config (BucketEndpoint bucket) "GET"
 
 
-getCollectionList : Config -> BucketName -> Task Error Json.Value
+getCollectionList :
+    Config
+    -> BucketName
+    -> (Result Error Json.Value -> msg)
+    -> Cmd msg
 getCollectionList config bucket =
     performQuery config (CollectionListEndpoint bucket) "GET"
 
 
-getCollection : Config -> BucketName -> CollectionName -> Task Error Json.Value
+getCollection :
+    Config
+    -> BucketName
+    -> CollectionName
+    -> (Result Error Json.Value -> msg)
+    -> Cmd msg
 getCollection config bucket collection =
     performQuery config (CollectionEndpoint bucket collection) "GET"
 
 
-getRecordList : Config -> BucketName -> CollectionName -> Task Error Json.Value
-getRecordList config bucket collection =
-    performQuery config (RecordListEndpoint bucket collection) "GET"
+getRecordList :
+    Config
+    -> BucketName
+    -> CollectionName
+    -> (Result Error Json.Value -> msg)
+    -> Cmd msg
+getRecordList config bucket collection toMsg =
+    performQuery config (RecordListEndpoint bucket collection) "GET" toMsg
 
 
 getRecord :
@@ -282,9 +300,11 @@ getRecord :
     -> BucketName
     -> CollectionName
     -> RecordId
-    -> Task Error Json.Value
-getRecord config bucket collection recordId =
+    -> (Result Error Json.Value -> msg)
+    -> Cmd msg
+getRecord config bucket collection recordId toMsg =
     performQuery
         config
         (RecordEndpoint bucket collection recordId)
         "GET"
+        toMsg

--- a/src/Kinto.elm
+++ b/src/Kinto.elm
@@ -151,7 +151,7 @@ performQuery config endpoint method toMsg =
                 , withCredentials = False
                 }
     in
-        Http.send (toKintoResponse toMsg) request
+        Http.send (toKintoResponse >> toMsg) request
 
 
 withHeader : String -> String -> Config -> Config
@@ -211,14 +211,10 @@ errorDecoder =
         (field "error" Json.string)
 
 
-toKintoResponse :
-    (Result Error Json.Value -> msg)
-    -> Result Http.Error Json.Value
-    -> msg
-toKintoResponse toMsg response =
+toKintoResponse : Result Http.Error Json.Value -> Result Error Json.Value
+toKintoResponse response =
     response
         |> Result.mapError extractError
-        |> toMsg
 
 
 extractError : Http.Error -> Error

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,6 +1,6 @@
 module Main exposing (..)
 
-import Html.App as Html
+import Html
 import Model exposing (..)
 import View exposing (view)
 
@@ -12,7 +12,7 @@ import View exposing (view)
 -- - Styling
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
     Html.program
         { init = init

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -2,8 +2,8 @@ module Model exposing (..)
 
 import Task
 import Time exposing (Time, second)
-import HttpBuilder exposing (Response, Error, send, withJsonBody, withHeader, jsonReader, stringReader)
-import Json.Decode exposing (Decoder, string, at, list, object4, (:=), maybe, int, Value, decodeValue)
+import HttpBuilder exposing (withJsonBody, withHeader, withExpect)
+import Json.Decode exposing (Decoder, string, at, list, map4, field, maybe, int, Value, decodeValue)
 import Json.Encode as Encode
 import Form
 import Dict
@@ -43,25 +43,21 @@ type alias Model =
 type Msg
     = NoOp
     | Tick Time
-    | HttpFail (Error String)
-    | KintoFail Kinto.Error
-    | FetchRecordSucceed Value
+    | FetchRecordResponse (Result Kinto.Error Value)
     | FetchRecords
-    | FetchRecordsSucceed Value
+    | FetchRecordsResponse (Result Kinto.Error Value)
     | FormMsg Form.Msg
-    | CreateRecordSucceed (Response Record)
+    | CreateRecordResponse (Result Http.Error Record)
     | EditRecord RecordId
-    | EditRecordSucceed (Response Record)
+    | EditRecordResponse (Result Http.Error Record)
     | DeleteRecord RecordId
-    | DeleteRecordSucceed (Response Record)
-    | TestClientFail Kinto.Error
-    | TestClient Json.Decode.Value
+    | DeleteRecordResponse (Result Http.Error Record)
 
 
 init : ( Model, Cmd Msg )
 init =
     ( initialModel
-    , Cmd.batch [ fetchRecords initialModel, testClient ]
+    , Cmd.batch [ fetchRecords initialModel ]
     )
 
 
@@ -69,16 +65,6 @@ config =
     Kinto.configure
         "https://kinto.dev.mozaws.net/v1/"
         (Kinto.Basic "test" "test")
-
-
-testClient : Cmd Msg
-testClient =
-    (Kinto.getRecordList
-        config
-        "default"
-        "test-items"
-    )
-        |> Task.perform TestClientFail TestClient
 
 
 initialModel : Model
@@ -108,49 +94,57 @@ update msg model =
         Tick newTime ->
             ( { model | currentTime = newTime }, Cmd.none )
 
-        HttpFail err ->
-            ( { model | error = Just (toString err) }, Cmd.none )
-
-        KintoFail err ->
-            let
-                _ =
-                    Debug.log "KintoFail error" err
-            in
-                ( model, Cmd.none )
-
         FetchRecords ->
             ( { model | records = Dict.empty, error = Nothing }, fetchRecords model )
 
-        FetchRecordSucceed data ->
-            case (decodeValue decodeRecord data) of
-                Err msg ->
-                    ( { model | error = Just msg }, Cmd.none )
+        FetchRecordResponse response ->
+            case response of
+                Ok data ->
+                    case (decodeValue decodeRecord data) of
+                        Err msg ->
+                            ( { model | error = Just msg }, Cmd.none )
 
-                Ok record ->
-                    ( { model
-                        | formData = recordToFormData record
-                        , error = Nothing
-                      }
-                    , Cmd.none
-                    )
+                        Ok record ->
+                            ( { model
+                                | formData = recordToFormData record
+                                , error = Nothing
+                              }
+                            , Cmd.none
+                            )
 
-        FetchRecordsSucceed data ->
-            let
-                recordsToDict records =
-                    List.map (\r -> ( r.id, r )) records
-                        |> Dict.fromList
-            in
-                case (decodeValue decodeRecords data) of
-                    Err msg ->
-                        ( { model | error = Just msg }, Cmd.none )
+                Err error ->
+                    let
+                        _ =
+                            Debug.log "FetchRecordResponse failed:" error
+                    in
+                        ( model, Cmd.none )
 
-                    Ok recordList ->
-                        ( { model
-                            | records = recordsToDict recordList
-                            , error = Nothing
-                          }
-                        , Cmd.none
-                        )
+        FetchRecordsResponse response ->
+            case response of
+                Ok data ->
+                    let
+                        recordsToDict records =
+                            List.map (\r -> ( r.id, r )) records
+                                |> Dict.fromList
+                    in
+                        case (decodeValue decodeRecords data) of
+                            Err msg ->
+                                ( { model | error = Just msg }, Cmd.none )
+
+                            Ok recordList ->
+                                ( { model
+                                    | records = recordsToDict recordList
+                                    , error = Nothing
+                                  }
+                                , Cmd.none
+                                )
+
+                Err error ->
+                    let
+                        _ =
+                            Debug.log "FetchRecordsResponse failed:" error
+                    in
+                        ( model, Cmd.none )
 
         FormMsg subMsg ->
             let
@@ -169,39 +163,40 @@ update msg model =
                     Just (Form.FormSubmitted data) ->
                         ( { model | formData = updated }, sendFormData data )
 
-        CreateRecordSucceed _ ->
-            ( { model | formData = Form.init }, fetchRecords model )
+        CreateRecordResponse response ->
+            case response of
+                Ok _ ->
+                    ( { model | formData = Form.init }, fetchRecords model )
+
+                Err err ->
+                    ( { model | error = Just (toString err) }, Cmd.none )
 
         EditRecord recordId ->
             ( model, fetchRecord model recordId )
 
-        EditRecordSucceed { data } ->
-            ( model, fetchRecords model )
+        EditRecordResponse response ->
+            case response of
+                Ok _ ->
+                    ( model, fetchRecords model )
+
+                Err err ->
+                    ( { model | error = Just (toString err) }, Cmd.none )
 
         DeleteRecord recordId ->
             ( model, deleteRecord recordId )
 
-        DeleteRecordSucceed { data } ->
-            ( { model
-                | records = removeRecordFromList data model.records
-                , error = Nothing
-              }
-            , fetchRecords model
-            )
+        DeleteRecordResponse response ->
+            case response of
+                Ok data ->
+                    ( { model
+                        | records = removeRecordFromList data model.records
+                        , error = Nothing
+                      }
+                    , fetchRecords model
+                    )
 
-        TestClient response ->
-            let
-                _ =
-                    Debug.log "response" response
-            in
-                ( model, Cmd.none )
-
-        TestClientFail err ->
-            let
-                _ =
-                    Debug.log "error" err
-            in
-                ( model, Cmd.none )
+                Err err ->
+                    ( { model | error = Just (toString err) }, Cmd.none )
 
 
 
@@ -219,20 +214,21 @@ subscriptions model =
 
 fetchRecord : Model -> RecordId -> Cmd Msg
 fetchRecord model recordId =
-    let
-        record =
-            Kinto.getRecord model.kintoConfig "default" "test-items" recordId
-    in
-        Task.perform KintoFail FetchRecordSucceed record
+    Kinto.getRecord
+        model.kintoConfig
+        "default"
+        "test-items"
+        recordId
+        FetchRecordResponse
 
 
 fetchRecords : Model -> Cmd Msg
 fetchRecords model =
-    let
-        recordList =
-            Kinto.getRecordList model.kintoConfig "default" "test-items"
-    in
-        Task.perform KintoFail FetchRecordsSucceed recordList
+    Kinto.getRecordList
+        model.kintoConfig
+        "default"
+        "test-items"
+        FetchRecordsResponse
 
 
 decodeRecords : Decoder (List Record)
@@ -242,11 +238,11 @@ decodeRecords =
 
 decodeRecord : Decoder Record
 decodeRecord =
-    object4 Record
-        ("id" := string)
-        (maybe ("title" := string))
-        (maybe ("description" := string))
-        ("last_modified" := int)
+    map4 Record
+        (field "id" string)
+        (maybe (field "title" string))
+        (maybe (field "description" string))
+        (field "last_modified" int)
 
 
 sendFormData : Form.Model -> Cmd Msg
@@ -256,22 +252,21 @@ sendFormData formData =
         rootUrl =
             "https://kinto.dev.mozaws.net/v1/buckets/default/collections/test-items/records"
 
-        ( method, url, failureMsg, successMsg ) =
+        ( method, url, responseMsg ) =
             case formData.id of
                 Nothing ->
-                    ( HttpBuilder.post, rootUrl, HttpFail, CreateRecordSucceed )
+                    ( HttpBuilder.post, rootUrl, CreateRecordResponse )
 
                 Just id ->
-                    ( HttpBuilder.patch, rootUrl ++ "/" ++ id, HttpFail, EditRecordSucceed )
+                    ( HttpBuilder.patch, rootUrl ++ "/" ++ id, EditRecordResponse )
 
         request =
             method url
-                |> withHeader "Content-Type" "application/json"
                 |> withHeader "Authorization" "Basic dGVzdDp0ZXN0"
                 |> withJsonBody (encodeFormData formData)
-                |> send (jsonReader (at [ "data" ] decodeRecord)) stringReader
+                |> withExpect (Http.expectJson (field "data" decodeRecord))
     in
-        Task.perform failureMsg successMsg request
+        HttpBuilder.send responseMsg request
 
 
 deleteRecord : RecordId -> Cmd Msg
@@ -283,11 +278,10 @@ deleteRecord recordId =
 
         request =
             HttpBuilder.delete delete_url
-                |> withHeader "Content-Type" "application/json"
                 |> withHeader "Authorization" "Basic dGVzdDp0ZXN0"
-                |> send (jsonReader (at [ "data" ] decodeRecord)) stringReader
+                |> withExpect (Http.expectJson (field "data" decodeRecord))
     in
-        Task.perform HttpFail DeleteRecordSucceed request
+        HttpBuilder.send DeleteRecordResponse request
 
 
 encodeFormData : Form.Model -> Encode.Value

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -113,11 +113,7 @@ update msg model =
                             )
 
                 Err error ->
-                    let
-                        _ =
-                            Debug.log "FetchRecordResponse failed:" error
-                    in
-                        ( model, Cmd.none )
+                    ( { model | error = Just <| toString error }, Cmd.none )
 
         FetchRecordsResponse response ->
             case response of

--- a/src/View.elm
+++ b/src/View.elm
@@ -3,8 +3,7 @@ module View exposing (view)
 import Time exposing (Time)
 import Html exposing (..)
 import Html.Events exposing (onClick)
-import Html.App
-import Html.Attributes exposing (id, for, attribute, class, type', value)
+import Html.Attributes exposing (id, for, attribute, class, value)
 import Utils exposing (timeAgo)
 import Model exposing (Model, Record, Records, Msg(..))
 import Form
@@ -76,5 +75,5 @@ view { error, records, formData, currentTime } =
         [ h1 [] [ text "Kinto Elm :-)" ]
         , errorNotif error
         , recordsList (sortedRecords records) currentTime
-        , Html.App.map FormMsg (Form.view formData)
+        , Html.map FormMsg (Form.view formData)
         ]

--- a/tests/KintoTests.elm
+++ b/tests/KintoTests.elm
@@ -30,13 +30,13 @@ all =
             [ test "returns the new header if previously empty" <|
                 \() ->
                     Expect.equal
-                        [ ( "foo", "bar" ) ]
+                        [ (Http.header "foo" "bar") ]
                         (config |> withHeader "foo" "bar").headers
             , test "adds the headers to the previous list of headers" <|
                 \() ->
                     Expect.equal
-                        [ ( "baz", "crux" )
-                        , ( "foo", "bar" )
+                        [ (Http.header "baz" "crux" )
+                        , (Http.header "foo" "bar" )
                         ]
                         (config
                             |> withHeader "foo" "bar"
@@ -47,13 +47,13 @@ all =
             [ test "adds the authentication headers to an empty config" <|
                 \() ->
                     Expect.equal
-                        [ ( "Authorization", "Basic dXNlcjpwYXNz" ) ]
+                        [ (Http.header "Authorization" "Basic dXNlcjpwYXNz" ) ]
                         (headersFromConfig authConfig)
             , test "adds the authentication headers to the existing ones" <|
                 \() ->
                     Expect.equal
-                        [ ( "Authorization", "Basic dXNlcjpwYXNz" )
-                        , ( "foo", "bar" )
+                        [ (Http.header "Authorization" "Basic dXNlcjpwYXNz" )
+                        , (Http.header "foo" "bar" )
                         ]
                         (headersFromConfig (withHeader "foo" "bar" authConfig))
             ]

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,11 +1,11 @@
 port module Main exposing (..)
 
 import Tests
-import Test.Runner.Node exposing (run)
+import Test.Runner.Node exposing (run, TestProgram)
 import Json.Encode exposing (Value)
 
 
-main : Program Value
+main : TestProgram
 main =
     run emit Tests.all
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -3,7 +3,6 @@ module Tests exposing (..)
 import Test exposing (..)
 import Expect
 import Utils exposing (timeAgo)
-
 import KintoTests
 
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,11 +9,11 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0",
-        "rtfeldman/node-test-runner": "2.0.0 <= v < 3.0.0",
-        "truqu/elm-base64": "1.0.4 <= v < 2.0.0"
+        "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0",
+        "truqu/elm-base64": "1.0.5 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
What do you think @n1k0 @glasserc @natim?

The big piece was coping with the API change between evancz/elm-http and
elm-lang/http (I like the new API a lot ;)

As a reminder: for the moment, only the GET APIs are included in the
"kinto.elm" library, so some "old" code is still around (for adding/editing).