### PR TITLE
Handle case insensitive response.headers

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,6 +10,7 @@
         "Kinto"
     ],
     "dependencies": {
+        "elm-community/dict-extra": "2.1.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "lukewestby/elm-http-builder": "4.0.0 <= v < 5.0.0",

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -9,11 +9,12 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "elm-community/dict-extra": "2.1.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
-        "mgold/elm-date-format": "1.1.7 <= v < 2.0.0",
         "lukewestby/elm-http-builder": "4.0.0 <= v < 5.0.0",
+        "mgold/elm-date-format": "1.1.7 <= v < 2.0.0",
         "truqu/elm-base64": "1.0.5 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/src/Kinto.elm
+++ b/src/Kinto.elm
@@ -314,12 +314,20 @@ decodePager : Client -> Decode.Decoder (List a) -> Http.Response String -> Resul
 decodePager client decoder response =
     let
         nextPage =
-            Dict.get "Next-Page" response.headers
+            if Dict.member "Next-Page" response.headers then
+                Dict.get "Next-Page" response.headers
+            else
+                Dict.get "next-page" response.headers
 
         total =
-            Dict.get "Total-Records" response.headers
-                |> Maybe.map (String.toInt >> Result.withDefault 0)
-                |> Maybe.withDefault 0
+            if Dict.member "Total-Records" response.headers then
+                Dict.get "Total-Records" response.headers
+                    |> Maybe.map (String.toInt >> Result.withDefault 0)
+                    |> Maybe.withDefault 0
+            else
+                Dict.get "total-records" response.headers
+                    |> Maybe.map (String.toInt >> Result.withDefault 0)
+                    |> Maybe.withDefault 0
 
         createPager objects =
             { client = client

--- a/src/Kinto.elm
+++ b/src/Kinto.elm
@@ -104,6 +104,7 @@ Item endpoints are:
 
 import Base64
 import Dict
+import Dict.Extra
 import Http
 import HttpBuilder
 import Json.Decode as Decode
@@ -313,21 +314,16 @@ updatePager nextPager previousPager =
 decodePager : Client -> Decode.Decoder (List a) -> Http.Response String -> Result.Result String (Pager a)
 decodePager client decoder response =
     let
+        headers =
+            Dict.Extra.mapKeys String.toLower response.headers
+
         nextPage =
-            if Dict.member "Next-Page" response.headers then
-                Dict.get "Next-Page" response.headers
-            else
-                Dict.get "next-page" response.headers
+            Dict.get "next-page" headers
 
         total =
-            if Dict.member "Total-Records" response.headers then
-                Dict.get "Total-Records" response.headers
-                    |> Maybe.map (String.toInt >> Result.withDefault 0)
-                    |> Maybe.withDefault 0
-            else
-                Dict.get "total-records" response.headers
-                    |> Maybe.map (String.toInt >> Result.withDefault 0)
-                    |> Maybe.withDefault 0
+            Dict.get "total-records" headers
+                |> Maybe.map (String.toInt >> Result.withDefault 0)
+                |> Maybe.withDefault 0
 
         createPager objects =
             { client = client

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -10,14 +10,14 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "elm-community/dict-extra": "2.1.0 <= v < 3.0.0",
         "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
-        "mgold/elm-random-pcg": "5.0.0 <= v < 6.0.0",
         "elm-community/lazy-list": "1.0.0 <= v < 2.0.0",
         "elm-community/shrink": "2.0.0 <= v < 3.0.0",
-
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "lukewestby/elm-http-builder": "4.0.0 <= v < 5.0.0",
+        "mgold/elm-random-pcg": "5.0.0 <= v < 6.0.0",
         "truqu/elm-base64": "1.0.5 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"


### PR DESCRIPTION
Refs https://stackoverflow.com/questions/44414594/how-to-dict-get-a-case-insensitive-key

It is the most obvious way I found. I guess it is not that bad even if something based on a `toLower` and `Dict.map` seams like a good idea too.