### PR TITLE
Fix example sort method

### DIFF
--- a/examples/Example.elm
+++ b/examples/Example.elm
@@ -88,7 +88,7 @@ getTodoList : Cmd Msg
 getTodoList =
     client
         |> Kinto.getList recordResource
-        |> Kinto.sortBy [ "title", "description" ]
+        |> Kinto.sort [ "title", "description" ]
         |> Kinto.send TodosFetched
 
 

--- a/examples/Model.elm
+++ b/examples/Model.elm
@@ -464,7 +464,7 @@ fetchRecordList { client, sort, limit } =
             Just client ->
                 client
                     |> Kinto.getList recordResource
-                    |> Kinto.sortBy [ sortColumn ]
+                    |> Kinto.sort [ sortColumn ]
                     |> limiter
                     |> Kinto.send FetchRecordsResponse
 


### PR DESCRIPTION
The example wouldn't compile, as sortBy was removed on https://github.com/Kinto/elm-kinto/pull/32, I'm using sort instead.

```
$ elm make Main.elm 
-- NAMING ERROR -------------------------------------------------- ././Model.elm

Cannot find variable `Kinto.sortBy`.

467|                     |> Kinto.sortBy [ sortColumn ]
                            ^^^^^^^^^^^^
`Kinto` does not expose `sortBy`. Maybe you want one of the following?

    Kinto.sort

Detected errors in 1 module
```