### PR TITLE
Fix exemple listing on create and change limit

### DIFF
--- a/examples/Example.elm
+++ b/examples/Example.elm
@@ -88,7 +88,7 @@ getTodoList : Cmd Msg
 getTodoList =
     client
         |> Kinto.getList recordResource
-        |> Kinto.sortBy [ "title", "description" ]
+        |> Kinto.sort [ "title", "description" ]
         |> Kinto.send TodosFetched
 
 

--- a/examples/Model.elm
+++ b/examples/Model.elm
@@ -315,7 +315,7 @@ update msg ({ clientFormData } as model) =
                 ( updated, Cmd.none )
 
         Limit ->
-            ( model, fetchRecordList model )
+            ( { model | pager = Nothing }, fetchRecordList model )
 
         UpdateClientServer server ->
             ( { model | clientFormData = { clientFormData | server = server } }, Cmd.none )

--- a/examples/Model.elm
+++ b/examples/Model.elm
@@ -190,13 +190,7 @@ update msg ({ clientFormData } as model) =
 
         CreateRecordResponse (Ok record) ->
             ( { model
-                | pager =
-                    case model.pager of
-                        Just pager ->
-                            Just <| addRecordToPager record pager
-
-                        Nothing ->
-                            Nothing
+                | pager = model.pager |> Maybe.map (addRecordToPager record)
                 , error = Nothing
               }
             , Cmd.none

--- a/examples/Model.elm
+++ b/examples/Model.elm
@@ -189,7 +189,7 @@ update msg ({ clientFormData } as model) =
             model |> updateError error
 
         CreateRecordResponse (Ok _) ->
-            ( { model | formData = initialFormData }
+            ( { model | formData = initialFormData, pager = Nothing }
             , fetchRecordList model
             )
 

--- a/examples/Model.elm
+++ b/examples/Model.elm
@@ -464,7 +464,7 @@ fetchRecordList { client, sort, limit } =
             Just client ->
                 client
                     |> Kinto.getList recordResource
-                    |> Kinto.sortBy [ sortColumn ]
+                    |> Kinto.sort [ sortColumn ]
                     |> limiter
                     |> Kinto.send FetchRecordsResponse
 

--- a/examples/Model.elm
+++ b/examples/Model.elm
@@ -298,7 +298,7 @@ update msg ({ clientFormData } as model) =
                                 (Asc column)
 
                 updated =
-                    { model | sort = sort }
+                    { model | sort = sort, pager = Nothing }
             in
                 ( updated, fetchRecordList updated )
 


### PR DESCRIPTION
Creating a new todo or changing the limit would create duplicated entries on the list. This fixes both behaviors.