### PR TITLE
Prevent elm to complaint at runtime about an invalid header name.

### DIFF
--- a/src/Kinto.elm
+++ b/src/Kinto.elm
@@ -497,7 +497,7 @@ headersForAuth : Auth -> ( String, String )
 headersForAuth auth =
     case auth of
         NoAuth ->
-            ( "", "" )
+            ( "Authorization", "" )
 
         Basic username password ->
             ( "Authorization"

--- a/tests/KintoTest.elm
+++ b/tests/KintoTest.elm
@@ -21,7 +21,7 @@ all =
             [ test "returns an empty header for NoAuth" <|
                 \() ->
                     Expect.equal
-                        ( "", "" )
+                        ( "Authorization", "" )
                         (Kinto.headersForAuth Kinto.NoAuth)
             , test "returns Basic Auth headers for Basic" <|
                 \() ->


### PR DESCRIPTION
Fixes #40 