### PR TITLE
Revisions to examples/package.json, mostly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+dist
 elm-stuff
 node_modules
 npm-debug.log

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ Experimenting with [Elm](elm-lang.org) and [Kinto](http://www.kinto-storage.org/
 
 ## Setup
 
-Node and Elm v0.18 should be installed on your system. Then:
+Node should be installed on your system. Then:
 
 ```
 $ npm install

--- a/examples/index.html
+++ b/examples/index.html
@@ -12,6 +12,8 @@
   </body>
 
   <script>
-    Elm.Main.embed(document.getElementById("root"));
+    var app = Elm.Main.init({
+      node: document.getElementById('root')
+    });
   </script>
 </html>

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Examples using the elm-kinto client",
   "scripts": {
-    "build": "mkdir -p dist && elm make Main.elm --debug --output=dist/app.js && elm make Example.elm --debug --output=dist/example.html",
+    "build": "mkdir -p dist && elm make Main.elm --optimize --output=dist/app.js && elm make Example.elm --optimize --output=dist/example.html",
     "debug": "mkdir -p build && cp index.html build/ && elm-live Main.elm --dir=build -- --debug --output=build/app.js",
     "live": "mkdir -p build && cp index.html build/ && elm-live Main.elm --dir=build -- --output=build/app.js",
     "publish-to-gh-pages": "mkdir -p dist && npm run build && cp index.html dist/ && gh-pages --dist dist/ && echo 'deployed to https://kinto.github.io/elm-kinto/'",

--- a/examples/package.json
+++ b/examples/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "description": "Examples using the elm-kinto client",
   "scripts": {
-    "build": "elm make Main.elm --optimize --output=app.js && elm make Example.elm --optimize --output=example.html ",
-    "debug": "cp index.html build/ && elm-live Main.elm --output=build/app.js --dir=build -- --debug",
-    "live": "cp index.html build/ && elm-live Main.elm --output=build/app.js --dir=build",
-    "publish-to-gh-pages": "npm run build && cp index.html build/ && gh-pages --dist build/ && echo 'deployed to https://kinto.github.io/elm-kinto/'",
+    "build": "mkdir -p dist && elm make Main.elm --debug --output=dist/app.js && elm make Example.elm --debug --output=dist/example.html",
+    "debug": "mkdir -p build && cp index.html build/ && elm-live Main.elm --dir=build -- --debug --output=build/app.js",
+    "live": "mkdir -p build && cp index.html build/ && elm-live Main.elm --dir=build -- --output=build/app.js",
+    "publish-to-gh-pages": "mkdir -p dist && npm run build && cp index.html dist/ && gh-pages --dist dist/ && echo 'deployed to https://kinto.github.io/elm-kinto/'",
     "tdd": "elm-test --watch",
     "test": "elm-test"
   },
@@ -24,7 +24,7 @@
     "elm": "^0.19.0",
     "elm-format": "^0.8.0",
     "elm-live": "^3.0.5",
-    "elm-test": "beta",
+    "elm-test": "^0.19.0",
     "gh-pages": "^0.11.0"
   }
 }


### PR DESCRIPTION
I'm hoping these changes will make the example code easier for others to follow and get running.

While setting it up, I encountered some issues with `examples/package.json`:

- `npm install` was failing due to 'elm-test' being assigned a version that didn't exist (now set to ^0.19)
- `npm run live` / `npm run debug` were failing due to placement of `--output`; now at the end behind a ` -- `

Additionally:
- my browser was failing to load app.js properly so there's a bit of rework in `examples/index.html`
- removed mention of installing Elm from `examples/README.md` as that'll get installed automatically from `package.json`