### PR TITLE
Remove total field in Pager, add count fn.

### DIFF
--- a/examples/Model.elm
+++ b/examples/Model.elm
@@ -144,10 +144,6 @@ update msg ({ clientFormData } as model) =
             ( { model | currentTime = newTime }, Cmd.none )
 
         CountRecordsResponse (Ok totalRecords) ->
-            let
-                _ =
-                    Debug.log "total" totalRecords
-            in
             ( { model | totalRecords = totalRecords }, Cmd.none )
 
         CountRecordsResponse (Err error) ->

--- a/examples/Model.elm
+++ b/examples/Model.elm
@@ -52,6 +52,7 @@ type alias Model =
     , currentTime : Posix
     , sort : Sort
     , maybeLimit : Maybe Int
+    , totalRecords : Int
     }
 
 
@@ -65,6 +66,7 @@ type Msg
       -- Use by TimeAgo to display human friendly timestamps
     | Tick Posix
       -- Kinto API requests
+    | CountRecordsResponse (Result Kinto.Error Int)
     | FetchRecordResponse (Result Kinto.Error Record)
     | FetchRecords
     | FetchNextRecords
@@ -97,7 +99,7 @@ type alias Flags =
 init : Flags -> ( Model, Cmd Msg )
 init flags =
     ( initialModel
-    , Cmd.batch [ fetchRecordList initialModel ]
+    , fetchData initialModel
     )
 
 
@@ -124,6 +126,7 @@ initialModel =
     , currentTime = Time.millisToPosix 0
     , sort = Desc "last_modified"
     , maybeLimit = Just 5
+    , totalRecords = 0
     }
 
 
@@ -140,6 +143,16 @@ update msg ({ clientFormData } as model) =
         Tick newTime ->
             ( { model | currentTime = newTime }, Cmd.none )
 
+        CountRecordsResponse (Ok totalRecords) ->
+            let
+                _ =
+                    Debug.log "total" totalRecords
+            in
+            ( { model | totalRecords = totalRecords }, Cmd.none )
+
+        CountRecordsResponse (Err error) ->
+            model |> updateError error
+
         FetchRecords ->
             ( { model
                 | maybePager =
@@ -151,7 +164,7 @@ update msg ({ clientFormData } as model) =
                             Nothing
                 , maybeError = Nothing
               }
-            , fetchRecordList model
+            , fetchData model
             )
 
         FetchNextRecords ->
@@ -169,7 +182,7 @@ update msg ({ clientFormData } as model) =
                 | formData = recordToFormData record
                 , maybeError = Nothing
               }
-            , Cmd.none
+            , countRecords model
             )
 
         FetchRecordResponse (Err error) ->
@@ -197,7 +210,7 @@ update msg ({ clientFormData } as model) =
                 | maybePager = model.maybePager |> Maybe.map (addRecordToPager record)
                 , maybeError = Nothing
               }
-            , Cmd.none
+            , countRecords model
             )
 
         CreateRecordResponse (Err error) ->
@@ -207,7 +220,7 @@ update msg ({ clientFormData } as model) =
             ( model, fetchRecord model.maybeClient recordId )
 
         EditRecordResponse (Ok _) ->
-            ( model, fetchRecordList model )
+            ( model, fetchData model )
 
         EditRecordResponse (Err error) ->
             model |> updateError error
@@ -226,7 +239,7 @@ update msg ({ clientFormData } as model) =
                             Nothing
                 , maybeError = Nothing
               }
-            , Cmd.none
+            , fetchData model
             )
 
         DeleteRecordResponse (Err error) ->
@@ -300,13 +313,13 @@ update msg ({ clientFormData } as model) =
                 updated =
                     { model | sort = sort, maybePager = Nothing }
             in
-            ( updated, fetchRecordList updated )
+            ( updated, fetchData updated )
 
         NewLimit newLimit ->
             ( { model | maybeLimit = String.toInt newLimit }, Cmd.none )
 
         Limit ->
-            ( { model | maybePager = Nothing }, fetchRecordList model )
+            ( { model | maybePager = Nothing }, fetchData model )
 
         UpdateClientServer server ->
             ( { model | clientFormData = { clientFormData | server = server } }, Cmd.none )
@@ -328,7 +341,7 @@ update msg ({ clientFormData } as model) =
                 newModel =
                     { model | maybePager = Nothing, maybeClient = client }
             in
-            ( newModel, fetchRecordList newModel )
+            ( newModel, fetchData newModel )
 
 
 updateError : Kinto.Error -> Model -> ( Model, Cmd Msg )
@@ -444,6 +457,23 @@ fetchNextRecordList pager =
     case Kinto.loadNextPage pager FetchRecordsResponse of
         Just request ->
             Kinto.send request
+
+        Nothing ->
+            Cmd.none
+
+
+fetchData : Model -> Cmd Msg
+fetchData model =
+    Cmd.batch [ fetchRecordList model, countRecords model ]
+
+
+countRecords : Model -> Cmd Msg
+countRecords { maybeClient } =
+    case maybeClient of
+        Just client ->
+            client
+                |> Kinto.count recordResource CountRecordsResponse
+                |> Kinto.send
 
         Nothing ->
             Cmd.none

--- a/examples/View.elm
+++ b/examples/View.elm
@@ -116,7 +116,7 @@ errorNotif error =
 
 
 view : Model -> Html.Html Msg
-view { maybeError, maybeClient, maybePager, formData, clientFormData, currentTime, sort, maybeLimit } =
+view { maybeError, maybeClient, maybePager, formData, clientFormData, currentTime, sort, maybeLimit, totalRecords } =
     let
         limit =
             maybeLimit
@@ -155,7 +155,7 @@ view { maybeError, maybeClient, maybePager, formData, clientFormData, currentTim
         , case maybePager of
             Just pager ->
                 Html.p []
-                    [ Html.text <| String.fromInt pager.total ++ " records in this collection." ]
+                    [ Html.text <| String.fromInt totalRecords ++ " records in this collection." ]
 
             Nothing ->
                 Html.text ""

--- a/src/Kinto.elm
+++ b/src/Kinto.elm
@@ -244,6 +244,10 @@ encodeData encoder =
 
 
 {-| A stateful accumulator for a paginated list of objects.
+
+**Note:** as of 8.0.0, the `total` field has been removed from the record. You
+must use the [`count`](#count) function to retrieve the total number of records.
+
 -}
 type alias Pager a =
     { client : Client

--- a/src/Kinto.elm
+++ b/src/Kinto.elm
@@ -484,7 +484,7 @@ expectTotalCount toMsg =
 
                 Http.GoodStatus_ { headers } _ ->
                     Dict.get "total-records" headers
-                        |> Maybe.map (String.toInt >> Maybe.withDefault 0)
+                        |> Maybe.andThen String.toInt
                         |> Maybe.withDefault 0
                         |> Ok
 

--- a/src/Kinto.elm
+++ b/src/Kinto.elm
@@ -2,7 +2,7 @@ module Kinto exposing
     ( Client, client, Auth(..), headersForAuth, Resource, bucketResource, collectionResource, recordResource, decodeData, encodeData, errorDecoder, errorToString
     , Request, withQueryParam
     , get, create, update, replace, delete
-    , getList
+    , getList, count
     , Pager, emptyPager, updatePager, loadNextPage
     , sort, limit, filter, Filter(..)
     , Endpoint(..), endpointUrl, ErrorDetail, Error(..), expectJson, expectPagerJson
@@ -51,7 +51,7 @@ Item endpoints are:
 
 ## Resource list requests
 
-@docs getList
+@docs getList, count
 
 
 ### Paginated list
@@ -249,7 +249,6 @@ type alias Pager a =
     { client : Client
     , objects : List a
     , decoder : Decode.Decoder (List a)
-    , total : Int
     , nextPage : Maybe Url
     }
 
@@ -264,7 +263,6 @@ emptyPager clientInstance resource =
     { client = clientInstance
     , objects = []
     , decoder = resource.listDecoder
-    , total = 0
     , nextPage = Nothing
     }
 
@@ -278,8 +276,7 @@ to the previous list.
 updatePager : Pager a -> Pager a -> Pager a
 updatePager nextPager previousPager =
     { previousPager
-        | total = nextPager.total
-        , nextPage = nextPager.nextPage
+        | nextPage = nextPager.nextPage
         , objects = previousPager.objects ++ nextPager.objects
     }
 
@@ -448,16 +445,10 @@ expectPagerJson toMsg clientInstance decoder =
                         nextPage =
                             Dict.get "next-page" headers
 
-                        total =
-                            Dict.get "total-records" headers
-                                |> Maybe.map (String.toInt >> Maybe.withDefault 0)
-                                |> Maybe.withDefault 0
-
                         createPager objects =
                             { client = clientInstance
                             , objects = objects
                             , decoder = decoder
-                            , total = total
                             , nextPage = nextPage
                             }
                     in
@@ -476,6 +467,26 @@ expectPagerJson toMsg clientInstance decoder =
                                         ++ body
                                     )
                                 )
+
+                anyError ->
+                    NetworkError anyError |> Err
+
+
+{-| Extract the value of the `Total-Records` header
+-}
+expectTotalCount : (Result Error Int -> msg) -> Http.Expect msg
+expectTotalCount toMsg =
+    Http.expectStringResponse toMsg <|
+        \response ->
+            case response of
+                Http.BadStatus_ { statusCode, statusText } body ->
+                    Err <| extractKintoError statusCode statusText body
+
+                Http.GoodStatus_ { headers } _ ->
+                    Dict.get "total-records" headers
+                        |> Maybe.map (String.toInt >> Maybe.withDefault 0)
+                        |> Maybe.withDefault 0
+                        |> Ok
 
                 anyError ->
                     NetworkError anyError |> Err
@@ -702,6 +713,20 @@ get resource itemId toMsg clientInstance =
         |> HttpBuilder.withExpect (expectJson toMsg resource.itemDecoder)
 
 
+{-| Count the number of records within a given collection
+
+    client
+        |> count resource CountReceived
+
+-}
+count : Resource a -> (Result Error Int -> msg) -> Client -> Request msg
+count resource toMsg clientInstance =
+    endpointUrl clientInstance.baseUrl resource.listEndpoint
+        |> HttpBuilder.head
+        |> HttpBuilder.withHeaders clientInstance.headers
+        |> HttpBuilder.withExpect (expectTotalCount toMsg)
+
+
 {-| Create a GET request on one of the plural endpoints. As lists are always
 possibly paginated, When the request is succesful, a `Pager` is attached to the
 reponse message.
@@ -715,8 +740,7 @@ getList resource toMsg clientInstance =
     endpointUrl clientInstance.baseUrl resource.listEndpoint
         |> HttpBuilder.get
         |> HttpBuilder.withHeaders clientInstance.headers
-        |> HttpBuilder.withExpect
-            (expectPagerJson toMsg clientInstance resource.listDecoder)
+        |> HttpBuilder.withExpect (expectPagerJson toMsg clientInstance resource.listDecoder)
 
 
 {-| If a pager has a `nextPage`, creates a GET request to retrieve the next page of objects.


### PR DESCRIPTION
This patch removes the `total` field of the `Pager` record type, because it's [not available anymore for `GET` request in Kinto](https://docs.kinto-storage.org/en/latest/api/1.x/records.html#count-of-stored-records) but only through an `HEAD` one. See related Kinto discussion [here](https://github.com/Kinto/kinto/issues/1624).

That's why the patch also adds a new `count` function so users can separately retrieve the total number of records available in a given collection.

This is gonna trigger a major release:

```
$ elm diff
This is a MAJOR change.

---- Kinto - MAJOR ----

    Added:
        count :
            Kinto.Resource a
            -> (Result.Result Kinto.Error Basics.Int -> msg)
            -> Kinto.Client
            -> Kinto.Request msg
    
    Changed:
      - type alias Pager a =
            { client : Client
            , objects : List a
            , decoder : Decoder (List a)
            , total : Int
            , nextPage : Maybe Url
            }
      + type alias Pager a =
            { client : Kinto.Client
            , objects : List.List a
            , decoder : Json.Decode.Decoder (List.List a)
            , nextPage : Maybe.Maybe Kinto.Url
            }
```